### PR TITLE
feat: custom css to get ride off tailwindcss

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,40 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Matthieu Bé - Profile web avec sources</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-gray-100">
-    <main class="min-h-screen w-full flex items-center justify-center p-4">
-        <div class="w-full max-w-sm bg-white p-6 md:p-8 rounded-2xl shadow-lg text-center">
-            <img src="https://cdn.masto.host/ludospherefr/accounts/avatars/108/293/895/794/966/618/original/99c08e12d896bcca.png" alt="Profile Picture" class="w-24 h-24 mx-auto rounded-full border-4 border-gray-300">
-           
-            <header class="mt-4">
-                <h1 class="text-xl md:text-2xl font-semibold">Matthieu</h1>
-                <p class="text-gray-500 mt-1">Juste fais-le</p>
+
+<body>
+    <main>
+        <div>
+            <img id="avatar"
+                src="https://cdn.masto.host/ludospherefr/accounts/avatars/108/293/895/794/966/618/original/99c08e12d896bcca.png"
+                alt="Profile Picture">
+
+            <header>
+                <h1>Matthieu</h1>
+                <p>Juste fais-le</p>
             </header>
-           
-            <nav class="mt-8 space-y-4" aria-label="Social links">
-                <a href="https://www.cestpasdujdr.fr/" class="block w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 transition-colors">C'est Pas Du JDR</a>
-                <a href="https://forthedrama.com/" class="block w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 transition-colors">For the Drama</a>
-                <a href="https://matthieu-be.itch.io/" class="block w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 transition-colors">Profil itch.io</a>
+
+            <nav aria-label="Social links">
+                <a href="https://www.cestpasdujdr.fr/">C'est Pas Du JDR</a>
+                <a href="https://forthedrama.com/">For the Drama</a>
+                <a href="https://matthieu-be.itch.io/">Profil itch.io</a>
             </nav>
 
-            <div class="flex justify-center gap-4 mt-6">
-                <a href="https://ludosphere.fr/@matthieu_be" class="inline-block" aria-label="Mastodon Profile">
-                    <svg class="w-6 h-6 text-gray-400 hover:text-gray-600 transition-colors" fill="currentColor" viewBox="0 0 16 16">
-                        <path d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z"/>
+            <div id="icons">
+                <a href="https://ludosphere.fr/@matthieu_be" aria-label="Mastodon Profile">
+                    <svg fill="currentColor" viewBox="0 0 16 16">
+                        <path
+                            d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z" />
                     </svg>
                 </a>
-                <a href="https://github.com/gorthal/profil-web/" class="inline-block" aria-label="GitHub Profile">
-                    <svg class="w-6 h-6 text-gray-400 hover:text-gray-600 transition-colors" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                <a href="https://github.com/gorthal/profil-web/" aria-label="GitHub Profile">
+                    <svg fill="currentColor" viewBox="0 0 24 24">
+                        <path
+                            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                     </svg>
                 </a>
             </div>
         </div>
     </main>
 </body>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,117 @@
+:root {
+  --font: ui-sans-serif, system-ui, sans-serif;
+
+  --background-color: rgb(243 244 246);
+
+  --card-color: rgb(255 255 255);
+
+  --button-text-color: rgb(255 255 255);
+  --button-background-color: rgb(17 24 39);
+  --button-background-color-hover: rgb(49, 65, 88);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background-color: var(--background-color);
+}
+
+main {
+  padding: 1rem;
+  min-height: 100dvh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+}
+
+main > div {
+  width: 100%;
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 2rem;
+  border-radius: 1rem;
+  background-color: var(--card-color);
+
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+  box-shadow: 0 0 #0000, 0 0 #0000, var(--tw-shadow);
+
+  text-align: center;
+}
+
+#avatar {
+  border: 4px solid rgb(209 213 219);
+  border-radius: 100%;
+  width: 6rem;
+  height: 6rem;
+}
+
+header {
+  margin-top: 1rem;
+}
+
+header > h1 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+header > p {
+  color: rgb(107 114 128);
+  margin: 0.25rem 0 0 0;
+}
+
+nav {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+nav > a {
+  display: block;
+  color: var(--button-text-color);
+  background-color: var(--button-background-color);
+  width: 100%;
+  font-weight: 500;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+
+  transition-property: color;
+  transition-duration: 150ms;
+}
+
+nav > a:hover {
+  background-color: var(--button-background-color-hover);
+}
+
+#icons {
+  margin-top: 1.5rem;
+  width: 100%;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+#icons > a > svg {
+  width: 1.5rem;
+  color: rgb(156 163 175);
+
+  transition-property: color;
+  transition-duration: 150ms;
+}
+
+#icons > a > svg:hover {
+  color: rgb(69, 85, 108);
+}


### PR DESCRIPTION
Petite réécriture du CSS pour un rendu quasi identique.
À noter l'ajout des `id` `icons` et `avatar` dans le HTML.
Le CSS peut aussi être minifié et intégré directement dans le HTML.
Les couleurs ont été regroupées sous forme de variable en haut du fichier CSS pour faciliter la personnalisation :art: 

Poids : 407 kB (tailwindcss) -> 1.9 kB (custom)